### PR TITLE
Default tox -elinters to python3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ install_command = pip install {opts} {packages}
 deps = -r{toxinidir}/test-requirements.txt
 
 [testenv:linters]
+basepython = python3
 commands =
   flake8 {posargs}
 


### PR DESCRIPTION
This is more inline with other roles in ansible-network, and allows us
to start using centos-7 nodes for testing.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>